### PR TITLE
specify charset to avoid Mojibake

### DIFF
--- a/webdav.conf
+++ b/webdav.conf
@@ -6,6 +6,7 @@ server {
   autoindex on;
 
   client_max_body_size 250M;
+  charset UTF-8;
 
   location /public {
     dav_methods            PUT DELETE MKCOL COPY MOVE;


### PR DESCRIPTION
I am getting mojibake when browsing exported webdav with Firefox, specifying charset here to avoid the issue.